### PR TITLE
Fix typo in command

### DIFF
--- a/restore_contexts.sh
+++ b/restore_contexts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-restore -RvF /etc/systemd/system \
+restorecon -RvF /etc/systemd/system \
             /etc/pihole \
             /etc/.pihole \
             /opt/pihole \


### PR DESCRIPTION
Fixes the error when running:
./restore_contexts.sh: line 3: restore: command not found

(Addresses #1)